### PR TITLE
remove kotlin & swift typo

### DIFF
--- a/computerscience/go/index.html
+++ b/computerscience/go/index.html
@@ -86,9 +86,9 @@
     <a href="https://houselearning.github.io/home/computerscience/java/index.html" target="_blank" rel="noopener noreferrer">Java</a>
     <a href="#jspage" target="_blank" rel="noopener noreferrer">JavaScript</a>
     <a href="https://houselearning.github.io/home/computerscience/ruby/index.html" target="_blank" rel="noopener noreferrer">Ruby</a>
-    <a href="https://houselearning.github.io/home/computerscience/swift/index.html" target="_blank" rel="noopener noreferrer" style="color:#a5d6a7; font-weight:700;">Swift</a>
+    <a href="https://houselearning.github.io/home/computerscience/swift/index.html" target="_blank" rel="noopener noreferrer">Swift</a>
     <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer">Kotlin</a>
-    <a href="https://houselearning.github.io/home/computerscience/go/index.html" target="_blank" rel="noopener noreferrer">Go</a>
+    <a href="https://houselearning.github.io/home/computerscience/go/index.html" target="_blank" rel="noopener noreferrer"><b>Go</b></a>
     <a href="https://houselearning.github.io/home/computerscience/php/index.html" target="_blank" rel="noopener noreferrer">PHP</a>
     <a href="https://houselearning.github.io/home/computerscience/typescript/index.html" target="_blank" rel="noopener noreferrer">TypeScript</a>
     <a href="https://houselearning.github.io/home/computerscience/r/index.html" target="_blank" rel="noopener noreferrer">R</a>

--- a/computerscience/java/index.html
+++ b/computerscience/java/index.html
@@ -83,11 +83,11 @@
     <a href="#csharp">C#</a>
     <a href="#games">Games</a>
     <a href="https://houselearning.github.io/home/computerscience/python/index.html" target="_blank" rel="noopener noreferrer">Python</a>
-    <a href="https://houselearning.github.io/home/computerscience/java/index.html" target="_blank" rel="noopener noreferrer">Java</a>
+    <a href="https://houselearning.github.io/home/computerscience/java/index.html" target="_blank" rel="noopener noreferrer"><b>Java</b></a>
     <a href="#jspage" target="_blank" rel="noopener noreferrer">JavaScript</a>
     <a href="https://houselearning.github.io/home/computerscience/ruby/index.html" target="_blank" rel="noopener noreferrer">Ruby</a>
     <a href="https://houselearning.github.io/home/computerscience/swift/index.html" target="_blank" rel="noopener noreferrer">Swift</a>
-    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer" style="color:#ffc107; font-weight:700;">Kotlin</a>
+    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer">Kotlin</a>
     <a href="https://houselearning.github.io/home/computerscience/go/index.html" target="_blank" rel="noopener noreferrer">Go</a>
     <a href="https://houselearning.github.io/home/computerscience/php/index.html" target="_blank" rel="noopener noreferrer">PHP</a>
     <a href="https://houselearning.github.io/home/computerscience/typescript/index.html" target="_blank" rel="noopener noreferrer">TypeScript</a>

--- a/computerscience/php/index.html
+++ b/computerscience/php/index.html
@@ -89,9 +89,9 @@
     <a href="#jspage" target="_blank" rel="noopener noreferrer">JavaScript</a>
     <a href="https://houselearning.github.io/home/computerscience/ruby/index.html" target="_blank" rel="noopener noreferrer">Ruby</a>
     <a href="https://houselearning.github.io/home/computerscience/swift/index.html" target="_blank" rel="noopener noreferrer">Swift</a>
-    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer" style="color:#ffc107; font-weight:700;">Kotlin</a>
+    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer">Kotlin</a>
     <a href="https://houselearning.github.io/home/computerscience/go/index.html" target="_blank" rel="noopener noreferrer">Go</a>
-    <a href="https://houselearning.github.io/home/computerscience/php/index.html" target="_blank" rel="noopener noreferrer">PHP</a>
+    <a href="https://houselearning.github.io/home/computerscience/php/index.html" target="_blank" rel="noopener noreferrer"><b>PHP</b></a>
     <a href="https://houselearning.github.io/home/computerscience/typescript/index.html" target="_blank" rel="noopener noreferrer">TypeScript</a>
     <a href="https://houselearning.github.io/home/computerscience/r/index.html" target="_blank" rel="noopener noreferrer">R</a>
     <a href="https://houselearning.github.io/home/computerscience/sql/index.html" target="_blank" rel="noopener noreferrer">SQL</a>

--- a/computerscience/python/index.html
+++ b/computerscience/python/index.html
@@ -82,12 +82,12 @@
     <a href="#web">Web Development</a>
     <a href="#csharp">C#</a>
     <a href="#games">Games</a>
-    <a href="https://houselearning.github.io/home/computerscience/python/index.html" target="_blank" rel="noopener noreferrer">Python</a>
+    <a href="https://houselearning.github.io/home/computerscience/python/index.html" target="_blank" rel="noopener noreferrer"><b>Python</b></a>
     <a href="https://houselearning.github.io/home/computerscience/java/index.html" target="_blank" rel="noopener noreferrer">Java</a>
     <a href="#jspage" target="_blank" rel="noopener noreferrer">JavaScript</a>
     <a href="https://houselearning.github.io/home/computerscience/ruby/index.html" target="_blank" rel="noopener noreferrer">Ruby</a>
     <a href="https://houselearning.github.io/home/computerscience/swift/index.html" target="_blank" rel="noopener noreferrer">Swift</a>
-    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer" style="color:#ffc107; font-weight:700;">Kotlin</a>
+    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer">Kotlin</a>
     <a href="https://houselearning.github.io/home/computerscience/go/index.html" target="_blank" rel="noopener noreferrer">Go</a>
     <a href="https://houselearning.github.io/home/computerscience/php/index.html" target="_blank" rel="noopener noreferrer">PHP</a>
     <a href="https://houselearning.github.io/home/computerscience/typescript/index.html" target="_blank" rel="noopener noreferrer">TypeScript</a>

--- a/computerscience/r/index.html
+++ b/computerscience/r/index.html
@@ -106,7 +106,7 @@
     <a href="https://houselearning.github.io/home/computerscience/go/index.html" target="_blank" rel="noopener noreferrer">Go</a>
     <a href="https://houselearning.github.io/home/computerscience/php/index.html" target="_blank" rel="noopener noreferrer">PHP</a>
     <a href="https://houselearning.github.io/home/computerscience/typescript/index.html" target="_blank" rel="noopener noreferrer">TypeScript</a>
-    <a href="https://houselearning.github.io/home/computerscience/r/index.html" target="_blank" rel="noopener noreferrer">R</a>
+    <a href="https://houselearning.github.io/home/computerscience/r/index.html" target="_blank" rel="noopener noreferrer"><b>R</b></a>
     <a href="https://houselearning.github.io/home/computerscience/sql/index.html" target="_blank" rel="noopener noreferrer">SQL</a>
     <a href="https://houselearning.github.io/home/computerscience/dart/index.html" target="_blank" rel="noopener noreferrer">Dart</a>
     <a href="https://houselearning.github.io/home/computerscience/matlab/index.html" target="_blank" rel="noopener noreferrer">MATLAB</a>

--- a/computerscience/ruby/index.html
+++ b/computerscience/ruby/index.html
@@ -85,9 +85,9 @@
     <a href="https://houselearning.github.io/home/computerscience/python/index.html" target="_blank" rel="noopener noreferrer">Python</a>
     <a href="https://houselearning.github.io/home/computerscience/java/index.html" target="_blank" rel="noopener noreferrer">Java</a>
     <a href="#jspage" target="_blank" rel="noopener noreferrer">JavaScript</a>
-    <a href="https://houselearning.github.io/home/computerscience/ruby/index.html" target="_blank" rel="noopener noreferrer">Ruby</a>
+    <a href="https://houselearning.github.io/home/computerscience/ruby/index.html" target="_blank" rel="noopener noreferrer"><b>Ruby</b></a>
     <a href="https://houselearning.github.io/home/computerscience/swift/index.html" target="_blank" rel="noopener noreferrer">Swift</a>
-    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer" style="color:#ffc107; font-weight:700;">Kotlin</a>
+    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer">Kotlin</a>
     <a href="https://houselearning.github.io/home/computerscience/go/index.html" target="_blank" rel="noopener noreferrer">Go</a>
     <a href="https://houselearning.github.io/home/computerscience/php/index.html" target="_blank" rel="noopener noreferrer">PHP</a>
     <a href="https://houselearning.github.io/home/computerscience/typescript/index.html" target="_blank" rel="noopener noreferrer">TypeScript</a>

--- a/computerscience/sql/index.html
+++ b/computerscience/sql/index.html
@@ -99,12 +99,12 @@
     <a href="#jspage" target="_blank" rel="noopener noreferrer">JavaScript</a>
     <a href="https://houselearning.github.io/home/computerscience/ruby/index.html" target="_blank" rel="noopener noreferrer">Ruby</a>
     <a href="https://houselearning.github.io/home/computerscience/swift/index.html" target="_blank" rel="noopener noreferrer">Swift</a>
-    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer" style="color:#ffc107; font-weight:700;">Kotlin</a>
+    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer">Kotlin</a>
     <a href="https://houselearning.github.io/home/computerscience/go/index.html" target="_blank" rel="noopener noreferrer">Go</a>
     <a href="https://houselearning.github.io/home/computerscience/php/index.html" target="_blank" rel="noopener noreferrer">PHP</a>
     <a href="https://houselearning.github.io/home/computerscience/typescript/index.html" target="_blank" rel="noopener noreferrer">TypeScript</a>
     <a href="https://houselearning.github.io/home/computerscience/r/index.html" target="_blank" rel="noopener noreferrer">R</a>
-    <a href="https://houselearning.github.io/home/computerscience/sql/index.html" target="_blank" rel="noopener noreferrer">SQL</a>
+    <a href="https://houselearning.github.io/home/computerscience/sql/index.html" target="_blank" rel="noopener noreferrer"><b>SQL</b></a>
     <a href="https://houselearning.github.io/home/computerscience/dart/index.html" target="_blank" rel="noopener noreferrer">Dart</a>
     <a href="https://houselearning.github.io/home/computerscience/matlab/index.html" target="_blank" rel="noopener noreferrer">MATLAB</a>
     <a href="https://houselearning.github.io/home/computerscience/bash/index.html" target="_blank" rel="noopener noreferrer">Bash</a>

--- a/computerscience/typescript/index.html
+++ b/computerscience/typescript/index.html
@@ -89,10 +89,10 @@
     <a href="#jspage" target="_blank" rel="noopener noreferrer">JavaScript</a>
     <a href="https://houselearning.github.io/home/computerscience/ruby/index.html" target="_blank" rel="noopener noreferrer">Ruby</a>
     <a href="https://houselearning.github.io/home/computerscience/swift/index.html" target="_blank" rel="noopener noreferrer">Swift</a>
-    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer" style="color:#ffc107; font-weight:700;">Kotlin</a>
+    <a href="https://houselearning.github.io/home/computerscience/kotlin/index.html" target="_blank" rel="noopener noreferrer">Kotlin</a>
     <a href="https://houselearning.github.io/home/computerscience/go/index.html" target="_blank" rel="noopener noreferrer">Go</a>
     <a href="https://houselearning.github.io/home/computerscience/php/index.html" target="_blank" rel="noopener noreferrer">PHP</a>
-    <a href="https://houselearning.github.io/home/computerscience/typescript/index.html" target="_blank" rel="noopener noreferrer">TypeScript</a>
+    <a href="https://houselearning.github.io/home/computerscience/typescript/index.html" target="_blank" rel="noopener noreferrer"><b>TypeScript</b></a>
     <a href="https://houselearning.github.io/home/computerscience/r/index.html" target="_blank" rel="noopener noreferrer">R</a>
     <a href="https://houselearning.github.io/home/computerscience/sql/index.html" target="_blank" rel="noopener noreferrer">SQL</a>
     <a href="https://houselearning.github.io/home/computerscience/dart/index.html" target="_blank" rel="noopener noreferrer">Dart</a>


### PR DESCRIPTION
on cs headings, **kotlin** and **swift** would always be bold
![image](https://github.com/user-attachments/assets/8238747e-fa98-4bef-adc4-378df06dc454)
![image](https://github.com/user-attachments/assets/8c87893b-76b8-4e17-91ec-1513eba24239)
