### PR TITLE
Potential fix for code scanning alert no. 80: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/.spellcheck.yml
+++ b/.github/workflows/.spellcheck.yml
@@ -1,6 +1,9 @@
 name: Spellcheck Action
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Spellcheck


### PR DESCRIPTION
Potential fix for [https://github.com/houselearning/home/security/code-scanning/80](https://github.com/houselearning/home/security/code-scanning/80)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here is to set workflow-level permissions right after `on:` and before `jobs:`:

- `contents: read` is the minimal recommended starting point and is sufficient for checkout + read-only checks.
- No imports, methods, or dependencies are needed since this is YAML configuration only.

Edit file: `.github/workflows/.spellcheck.yml`  
Change region: top-level keys near lines 1–4, inserting `permissions:` between `on:` and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
