### PR TITLE
Fix for Superfluous trailing arguments

### DIFF
--- a/computerscience/compiler.html
+++ b/computerscience/compiler.html
@@ -1825,7 +1825,7 @@ _start:
             initialVars[match[1]] = match[2].trim();
         }
 
-        renderWatchPanel(initialVars, 'variableWatchPre', 'Initial State');
+        renderWatchPanel(initialVars, 'variableWatchPre');
     }
     
     function renderWatchPanel(vars, containerId) {


### PR DESCRIPTION
The best fix without changing current functionality is to remove the unused third argument at the call site in `preRunAnalysis`.  
This keeps behavior identical (since the third argument is currently ignored) while making the call match the function signature.

Change needed:

- **File:** `computerscience/compiler.html`
- **Region:** around line 1828 in `preRunAnalysis`
- Replace:
  - `renderWatchPanel(initialVars, 'variableWatchPre', 'Initial State');`
- With:
  - `renderWatchPanel(initialVars, 'variableWatchPre');`

No imports, dependencies, or additional method definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._