### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/games/graph-gauntlet.html
+++ b/games/graph-gauntlet.html
@@ -242,8 +242,7 @@
         let auth;
         let userId = 'anonymous'; // Default to anonymous
 
-        // Get app ID and Firebase config from the environment
-        const appId = typeof __app_id !== 'undefined' ? __app_id : 'default-app-id';
+        // Get Firebase config from the environment
         const firebaseConfig = typeof __firebase_config !== 'undefined' ? JSON.parse(__firebase_config) : {};
 
         // Initialize Firebase


### PR DESCRIPTION
To fix the problem, we should eliminate the unused variable so that the code only defines values that are actually used. The simplest, behavior‑preserving approach is to remove the `const appId = ...` declaration entirely. Since nothing in the shown code reads `appId`, removing it does not alter functionality. If you want to preserve the intent/documentation, you could instead leave only a comment explaining that an app ID could be provided via `__app_id`, but the variable itself should not be declared unless needed.

Concretely, in `games/graph-gauntlet.html` around line 245–247, delete the line that declares `appId` and keep the `firebaseConfig` declaration untouched. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._